### PR TITLE
Add post visibility controls

### DIFF
--- a/db.php
+++ b/db.php
@@ -5,7 +5,7 @@ function get_db() {
         $db = new PDO('sqlite:' . __DIR__ . '/blog.db');
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
-        $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, section_id INTEGER)");
+        $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, section_id INTEGER, is_public INTEGER NOT NULL DEFAULT 1)");
         $db->exec("CREATE TABLE IF NOT EXISTS sections (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, parent_id INTEGER REFERENCES sections(id))");
         $db->exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
 
@@ -13,6 +13,9 @@ function get_db() {
         $columns = $db->query("PRAGMA table_info(posts)")->fetchAll(PDO::FETCH_COLUMN, 1);
         if (!in_array('section_id', $columns)) {
             $db->exec("ALTER TABLE posts ADD COLUMN section_id INTEGER");
+        }
+        if (!in_array('is_public', $columns)) {
+            $db->exec("ALTER TABLE posts ADD COLUMN is_public INTEGER NOT NULL DEFAULT 1");
         }
         $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'blog_title'");
         $stmt->execute();

--- a/edit_post.php
+++ b/edit_post.php
@@ -4,7 +4,7 @@ require_login();
 
 $db = get_db();
 $id = intval($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT title, content, section_id FROM posts WHERE id = ?");
+$stmt = $db->prepare("SELECT title, content, section_id, is_public FROM posts WHERE id = ?");
 $stmt->execute([$id]);
 $post = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$post) {
@@ -15,6 +15,7 @@ if (!$post) {
 $title = $post['title'];
 $content = $post['content'];
 $section_id = (int)$post['section_id'];
+$is_public = (int)$post['is_public'] === 1 ? 1 : 0;
 $section = null;
 if ($section_id) {
     $secStmt = $db->prepare("SELECT title FROM sections WHERE id = ?");
@@ -27,9 +28,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $title = ucwords(strtolower($title));
     $content = trim($_POST['content'] ?? '');
+    $is_public = isset($_POST['is_public']) && $_POST['is_public'] === '0' ? 0 : 1;
     if ($title && $content) {
-        $update = $db->prepare("UPDATE posts SET title = ?, content = ? WHERE id = ?");
-        $update->execute([$title, $content, $id]);
+        $update = $db->prepare("UPDATE posts SET title = ?, content = ?, is_public = ? WHERE id = ?");
+        $update->execute([$title, $content, $is_public, $id]);
         header('Location: view_post.php?id=' . $id);
         exit();
     } else {
@@ -54,6 +56,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <label for="content">Content (Markdown supported)</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<fieldset>
+<legend>Visibility</legend>
+<label><input type="radio" name="is_public" value="1" <?php echo $is_public ? 'checked' : ''; ?>> Public</label><br>
+<label><input type="radio" name="is_public" value="0" <?php echo !$is_public ? 'checked' : ''; ?>> Private</label>
+</fieldset>
 <button type="submit">Update</button>
 </form>
 <?php if ($section): ?>

--- a/index.php
+++ b/index.php
@@ -4,7 +4,14 @@ $db = get_db();
 $blog_title = get_blog_title();
 
 $sections = $db->query("SELECT id, title FROM sections WHERE parent_id IS NULL ORDER BY title")->fetchAll(PDO::FETCH_ASSOC);
-$posts = $db->query("SELECT id, title FROM posts WHERE section_id IS NULL ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+if (is_logged_in()) {
+    $postStmt = $db->prepare("SELECT id, title FROM posts WHERE section_id IS NULL ORDER BY created_at DESC");
+    $postStmt->execute();
+} else {
+    $postStmt = $db->prepare("SELECT id, title FROM posts WHERE section_id IS NULL AND is_public = 1 ORDER BY created_at DESC");
+    $postStmt->execute();
+}
+$posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
 <html>

--- a/new_post.php
+++ b/new_post.php
@@ -7,6 +7,7 @@ $title = '';
 $content = '';
 $message = '';
 $section_id = isset($_GET['section_id']) ? intval($_GET['section_id']) : intval($_POST['section_id'] ?? 0);
+$is_public = isset($_POST['is_public']) ? (int)($_POST['is_public'] === '1') : 1;
 
 $section = null;
 if ($section_id) {
@@ -20,8 +21,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = ucwords(strtolower($title));
     $content = trim($_POST['content'] ?? '');
     if ($title && $content) {
-        $stmt = $db->prepare("INSERT INTO posts (title, content, section_id) VALUES (?, ?, ?)");
-        $stmt->execute([$title, $content, $section_id ?: null]);
+        $is_public = isset($_POST['is_public']) && $_POST['is_public'] === '0' ? 0 : 1;
+        $stmt = $db->prepare("INSERT INTO posts (title, content, section_id, is_public) VALUES (?, ?, ?, ?)");
+        $stmt->execute([$title, $content, $section_id ?: null, $is_public]);
         if ($section_id) {
             header('Location: view_section.php?id=' . $section_id);
         } else {
@@ -51,6 +53,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <label for="content">Content (Markdown supported)</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
 <input type="hidden" name="section_id" value="<?php echo htmlspecialchars($section_id); ?>">
+<fieldset>
+<legend>Visibility</legend>
+<label><input type="radio" name="is_public" value="1" <?php echo $is_public ? 'checked' : ''; ?>> Public</label><br>
+<label><input type="radio" name="is_public" value="0" <?php echo !$is_public ? 'checked' : ''; ?>> Private</label>
+</fieldset>
 <button type="submit">Publish</button>
 </form>
 <?php if ($section): ?>

--- a/view_post.php
+++ b/view_post.php
@@ -4,10 +4,10 @@ require_once __DIR__ . '/markdown.php';
 $db = get_db();
 $blog_title = get_blog_title();
 $id = (int)($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT id, title, content, created_at, section_id FROM posts WHERE id = ?");
+$stmt = $db->prepare("SELECT id, title, content, created_at, section_id, is_public FROM posts WHERE id = ?");
 $stmt->execute([$id]);
 $post = $stmt->fetch(PDO::FETCH_ASSOC);
-if (!$post) {
+if (!$post || (!$post['is_public'] && !is_logged_in())) {
     http_response_code(404);
     echo "<p>Post not found.</p>\n";
     exit();
@@ -38,6 +38,7 @@ if ($post['section_id']) {
 ?>
 <small>
     <time datetime="<?php echo $iso; ?>"><?php echo $display; ?></time>
+    <?php if (!$post['is_public']): ?> | Private<?php endif; ?>
     <?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a> | <a href="delete_post.php?id=<?php echo $post['id']; ?>" onclick="return confirm('Delete this post?');">Delete</a><?php endif; ?>
 </small>
 </article>

--- a/view_section.php
+++ b/view_section.php
@@ -24,7 +24,11 @@ $subStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id = ? ORDE
 $subStmt->execute([$id]);
 $subsections = $subStmt->fetchAll(PDO::FETCH_ASSOC);
 
-$postStmt = $db->prepare("SELECT id, title FROM posts WHERE section_id = ? ORDER BY created_at DESC");
+$postStmt = $db->prepare(
+    is_logged_in()
+        ? "SELECT id, title FROM posts WHERE section_id = ? ORDER BY created_at DESC"
+        : "SELECT id, title FROM posts WHERE section_id = ? AND is_public = 1 ORDER BY created_at DESC"
+);
 $postStmt->execute([$id]);
 $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>


### PR DESCRIPTION
## Summary
- add a visibility flag to posts in the database schema
- allow bloggers to choose public or private visibility when creating and editing posts
- hide private posts from public listings and display a marker when viewing as the owner

## Testing
- php -l db.php
- php -l new_post.php
- php -l edit_post.php
- php -l index.php
- php -l view_section.php
- php -l view_post.php

------
https://chatgpt.com/codex/tasks/task_e_68de7ab0f2f4832b9839417c13256d82