### PR TITLE
Improve post editor responsiveness on mobile

### DIFF
--- a/edit_post.php
+++ b/edit_post.php
@@ -43,6 +43,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Edit Post</title>
+<style>
+input[type="text"],
+.editor-field {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+</style>
 </head>
 <body>
 <h1>Edit Post</h1>
@@ -53,7 +61,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <label for="title">Title</label><br>
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <label for="content">Content (Markdown supported)</label><br>
-<textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<textarea name="content" id="content" class="editor-field" rows="10"><?php echo htmlspecialchars($content); ?></textarea><br>
 <button type="submit">Update</button>
 </form>
 <?php if ($section): ?>

--- a/new_post.php
+++ b/new_post.php
@@ -39,6 +39,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>New Post</title>
+<style>
+input[type="text"],
+.editor-field {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+</style>
 </head>
 <body>
 <h1>New Post</h1>
@@ -49,7 +57,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <label for="title">Title</label><br>
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <label for="content">Content (Markdown supported)</label><br>
-<textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<textarea name="content" id="content" class="editor-field" rows="10"><?php echo htmlspecialchars($content); ?></textarea><br>
 <input type="hidden" name="section_id" value="<?php echo htmlspecialchars($section_id); ?>">
 <button type="submit">Publish</button>
 </form>


### PR DESCRIPTION
## Summary
- add responsive styling for post form title inputs and editor textareas
- replace fixed textarea columns with a shared editor class on edit and new post forms

## Testing
- Manually verified new and edit post pages in a 375px-wide browser viewport

------
https://chatgpt.com/codex/tasks/task_e_68e048404734832ba4d12b9f6d75a6b6