### PR TITLE
Add password reset workflow and email settings

### DIFF
--- a/edit_user.php
+++ b/edit_user.php
@@ -3,17 +3,33 @@ require_once __DIR__ . '/auth.php';
 require_login();
 
 $db = get_db();
-$current_username = $_SESSION['username'];
+
+$stmt = $db->prepare('SELECT username, email FROM users WHERE id = ?');
+$stmt->execute([$_SESSION['user_id']]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$user) {
+    logout();
+    header('Location: login.php');
+    exit();
+}
+
+$current_username = $user['username'];
+$current_email = $user['email'] ?? '';
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $new_username = trim($_POST['username'] ?? '');
+    $new_email_input = trim($_POST['email'] ?? '');
+    $new_email = $new_email_input === '' ? null : $new_email_input;
 
     $new_password = $_POST['new_password'] ?? '';
     $confirm_password = $_POST['confirm_password'] ?? '';
 
     if ($new_username === '') {
         $message = 'Username is required';
+    } elseif ($new_email_input !== '' && !filter_var($new_email_input, FILTER_VALIDATE_EMAIL)) {
+        $message = 'Please enter a valid email address';
     } elseif ($new_password !== '' && $new_password !== $confirm_password) {
         $message = 'New passwords do not match';
     } else {
@@ -29,6 +45,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $params[] = $new_username;
             }
         }
+        if ($new_email !== ($user['email'] ?? null)) {
+            if ($new_email === null) {
+                $updates[] = 'email = NULL';
+            } else {
+                $check = $db->prepare('SELECT COUNT(*) FROM users WHERE email = ? AND id != ?');
+                $check->execute([$new_email, $_SESSION['user_id']]);
+                if ($check->fetchColumn() > 0) {
+                    $message = 'Email address already in use';
+                } else {
+                    $updates[] = 'email = ?';
+                    $params[] = $new_email;
+                }
+            }
+        }
         if ($new_password !== '') {
             $updates[] = 'password = ?';
             $params[] = password_hash($new_password, PASSWORD_DEFAULT);
@@ -40,6 +70,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt = $db->prepare($sql);
                 $stmt->execute($params);
                 $_SESSION['username'] = $new_username;
+                $current_username = $new_username;
+                $current_email = $new_email_input;
                 header('Location: index.php');
                 exit();
             } else {
@@ -54,16 +86,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
 <meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'>
-<title>Edit Account</title>
+<title>Account Settings</title>
 </head>
 <body>
-<h1>Edit Account</h1>
+<h1>Account Settings</h1>
 <?php if ($message): ?>
 <p><?php echo htmlspecialchars($message); ?></p>
 <?php endif; ?>
 <form method='post'>
 <label for='username'>Username</label><br>
 <input type='text' name='username' id='username' value='<?php echo htmlspecialchars($current_username); ?>'><br>
+<label for='email'>Email</label><br>
+<input type='email' name='email' id='email' value='<?php echo htmlspecialchars($current_email); ?>'><br>
 <label for='new_password'>New Password</label><br>
 <input type='password' name='new_password' id='new_password'><br>
 <label for='confirm_password'>Confirm New Password</label><br>

--- a/forgot_password.php
+++ b/forgot_password.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+$message = '';
+$showForm = true;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+
+    if ($email === '') {
+        $message = 'Please enter your email address.';
+    } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $message = 'Please enter a valid email address.';
+    } else {
+        $db = get_db();
+        $db->prepare('DELETE FROM password_resets WHERE expires_at < ?')->execute([time()]);
+
+        $stmt = $db->prepare('SELECT id FROM users WHERE email = ?');
+        $stmt->execute([$email]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($user) {
+            $db->prepare('DELETE FROM password_resets WHERE user_id = ?')->execute([$user['id']]);
+
+            $token = bin2hex(random_bytes(32));
+            $expiresAt = time() + 3600; // 1 hour
+
+            $insert = $db->prepare('INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)');
+            $insert->execute([$user['id'], $token, $expiresAt]);
+
+            $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+            $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+            $basePath = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/\\');
+            $resetLink = $scheme . '://' . $host . ($basePath ? $basePath . '/' : '/') . 'reset_password.php?token=' . urlencode($token);
+
+            $subject = 'Password Reset Request';
+            $body = "A password reset was requested for your account.\n\n" .
+                "Use the link below to set a new password. This link will expire in one hour.\n\n" .
+                $resetLink . "\n\n" .
+                "If you did not request a reset, you can ignore this email.";
+
+            @mail($email, $subject, $body);
+        }
+
+        $message = 'If an account with that email exists, a password reset link has been sent.';
+        $showForm = false;
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Forgot Password</title>
+</head>
+<body>
+<h1>Forgot Password</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<?php if ($showForm): ?>
+<form method="post">
+<label for="email">Email</label><br>
+<input type="email" name="email" id="email" required><br>
+<button type="submit">Send Reset Link</button>
+</form>
+<?php endif; ?>
+<p><a href="login.php">Back to Login</a></p>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ $posts = $db->query("SELECT id, title FROM posts WHERE section_id IS NULL ORDER 
 <h1><?php echo htmlspecialchars($blog_title); ?></h1>
 <h2>Index</h2>
 <?php if (is_logged_in()): ?>
-<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_section.php">New Section</a> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Edit Account</a> | <a href="logout.php">Logout</a></p>
+<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_section.php">New Section</a> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Settings</a> | <a href="logout.php">Logout</a></p>
 <?php else: ?>
 <p><a href="login.php">Login</a></p>
 <?php endif; ?>

--- a/login.php
+++ b/login.php
@@ -37,5 +37,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="password" name="password" id="password"><br>
 <button type="submit">Login</button>
 </form>
+<p><a href="forgot_password.php">Forgot your password?</a></p>
 </body>
 </html>

--- a/reset_password.php
+++ b/reset_password.php
@@ -1,0 +1,68 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+$db = get_db();
+$message = '';
+$token = $_GET['token'] ?? ($_POST['token'] ?? '');
+$token = trim($token);
+$showForm = true;
+
+if ($token === '') {
+    $message = 'Invalid password reset token.';
+    $showForm = false;
+} else {
+    $stmt = $db->prepare('SELECT pr.user_id, pr.expires_at, u.email FROM password_resets pr JOIN users u ON pr.user_id = u.id WHERE pr.token = ?');
+    $stmt->execute([$token]);
+    $reset = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$reset || $reset['expires_at'] < time()) {
+        $message = 'This password reset link is invalid or has expired.';
+        $showForm = false;
+        if ($reset) {
+            $db->prepare('DELETE FROM password_resets WHERE token = ?')->execute([$token]);
+        }
+    } elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $new_password = $_POST['new_password'] ?? '';
+        $confirm_password = $_POST['confirm_password'] ?? '';
+
+        if ($new_password === '') {
+            $message = 'Please enter a new password.';
+        } elseif ($new_password !== $confirm_password) {
+            $message = 'Passwords do not match.';
+        } else {
+            $update = $db->prepare('UPDATE users SET password = ? WHERE id = ?');
+            $update->execute([password_hash($new_password, PASSWORD_DEFAULT), $reset['user_id']]);
+
+            $db->prepare('DELETE FROM password_resets WHERE user_id = ?')->execute([$reset['user_id']]);
+
+            $message = 'Your password has been reset. You can now log in.';
+            $showForm = false;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Reset Password</title>
+</head>
+<body>
+<h1>Reset Password</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<?php if ($showForm): ?>
+<form method="post">
+<input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
+<label for="new_password">New Password</label><br>
+<input type="password" name="new_password" id="new_password" required><br>
+<label for="confirm_password">Confirm Password</label><br>
+<input type="password" name="confirm_password" id="confirm_password" required><br>
+<button type="submit">Reset Password</button>
+</form>
+<?php endif; ?>
+<p><a href="login.php">Return to Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an email column for users and store password reset tokens in the database
- let the logged-in blogger manage their username, email, and password from the account settings page
- add a full forgot/reset password flow and surface it from the login screen

## Testing
- for file in db.php edit_user.php index.php login.php forgot_password.php reset_password.php; do php -l "$file"; done


------
https://chatgpt.com/codex/tasks/task_e_68e052a22480832ba689c7d0922b93ea