### PR TITLE
Add configurable templates for sections

### DIFF
--- a/db.php
+++ b/db.php
@@ -6,7 +6,7 @@ function get_db() {
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
         $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, section_id INTEGER, is_public INTEGER NOT NULL DEFAULT 1)");
-        $db->exec("CREATE TABLE IF NOT EXISTS sections (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, parent_id INTEGER REFERENCES sections(id))");
+        $db->exec("CREATE TABLE IF NOT EXISTS sections (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, parent_id INTEGER REFERENCES sections(id), template TEXT DEFAULT '')");
         $db->exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
 
         // Ensure the section_id column exists for older installations
@@ -16,6 +16,11 @@ function get_db() {
         }
         if (!in_array('is_public', $columns)) {
             $db->exec("ALTER TABLE posts ADD COLUMN is_public INTEGER NOT NULL DEFAULT 1");
+        }
+
+        $sectionColumns = $db->query("PRAGMA table_info(sections)")->fetchAll(PDO::FETCH_COLUMN, 1);
+        if (!in_array('template', $sectionColumns)) {
+            $db->exec("ALTER TABLE sections ADD COLUMN template TEXT DEFAULT ''");
         }
         $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'blog_title'");
         $stmt->execute();

--- a/edit_section.php
+++ b/edit_section.php
@@ -6,7 +6,7 @@ $db = get_db();
 $blog_title = get_blog_title();
 
 $id = intval($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT title, parent_id FROM sections WHERE id = ?");
+$stmt = $db->prepare("SELECT title, parent_id, template FROM sections WHERE id = ?");
 $stmt->execute([$id]);
 $section = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$section) {
@@ -15,15 +15,17 @@ if (!$section) {
 }
 
 $title = $section['title'];
+$template = $section['template'] ?? '';
 $parent_id = (int)$section['parent_id'];
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $title = ucwords(strtolower($title));
+    $template = $_POST['template'] ?? '';
     if ($title) {
-        $update = $db->prepare("UPDATE sections SET title = ? WHERE id = ?");
-        $update->execute([$title, $id]);
+        $update = $db->prepare("UPDATE sections SET title = ?, template = ? WHERE id = ?");
+        $update->execute([$title, $template, $id]);
         header('Location: view_section.php?id=' . $id);
         exit();
     } else {
@@ -45,6 +47,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <form method="post">
 <label for="title">Title</label><br>
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<label for="template">Template</label><br>
+<textarea name="template" id="template" rows="8" cols="60"><?php echo htmlspecialchars($template); ?></textarea><br>
 <button type="submit">Update</button>
 </form>
 <p><a href="view_section.php?id=<?php echo $id; ?>">Back to <?php echo htmlspecialchars($title); ?></a></p>

--- a/new_post.php
+++ b/new_post.php
@@ -11,9 +11,13 @@ $is_public = isset($_POST['is_public']) ? (int)($_POST['is_public'] === '1') : 1
 
 $section = null;
 if ($section_id) {
-    $stmt = $db->prepare("SELECT title FROM sections WHERE id = ?");
+    $stmt = $db->prepare("SELECT title, template FROM sections WHERE id = ?");
     $stmt->execute([$section_id]);
     $section = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+if ($section && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $content = $section['template'] ?? '';
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/new_section.php
+++ b/new_section.php
@@ -13,14 +13,16 @@ if ($parent_id) {
     $parent = $stmt->fetch(PDO::FETCH_ASSOC);
 }
 $title = '';
+$template = '';
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $title = ucwords(strtolower($title));
+    $template = $_POST['template'] ?? '';
     if ($title) {
-        $stmt = $db->prepare("INSERT INTO sections (title, parent_id) VALUES (?, ?)");
-        $stmt->execute([$title, $parent_id ?: null]);
+        $stmt = $db->prepare("INSERT INTO sections (title, parent_id, template) VALUES (?, ?, ?)");
+        $stmt->execute([$title, $parent_id ?: null, $template]);
         if ($parent_id) {
             header('Location: view_section.php?id=' . $parent_id);
         } else {
@@ -46,6 +48,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <form method="post">
 <label for="title">Title</label><br>
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<label for="template">Template</label><br>
+<textarea name="template" id="template" rows="8" cols="60"><?php echo htmlspecialchars($template); ?></textarea><br>
 <input type="hidden" name="parent_id" value="<?php echo htmlspecialchars($parent_id); ?>">
 <button type="submit">Create</button>
 </form>


### PR DESCRIPTION
## Summary
- allow sections to persist a reusable content template in the database
- expose template fields when creating or editing sections and prefill new posts with the selected section template

## Testing
- php -l db.php
- php -l new_section.php
- php -l edit_section.php
- php -l new_post.php

------
https://chatgpt.com/codex/tasks/task_e_68e092bbd560832bb443b6f3e423fd80