### PR TITLE
Ensure text inputs and textareas span full width

### DIFF
--- a/edit_post.php
+++ b/edit_post.php
@@ -50,14 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Edit Post</title>
-<style>
-input[type="text"],
-.editor-field {
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-}
-</style>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1>Edit Post</h1>

--- a/edit_section.php
+++ b/edit_section.php
@@ -39,14 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Edit Section</title>
-<style>
-input[type="text"],
-textarea {
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-}
-</style>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>

--- a/edit_title.php
+++ b/edit_title.php
@@ -22,6 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Edit Title</title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1>Edit Title</h1>

--- a/edit_user.php
+++ b/edit_user.php
@@ -55,6 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'>
 <title>Edit Account</title>
+<link rel='stylesheet' href='styles.css'>
 </head>
 <body>
 <h1>Edit Account</h1>

--- a/index.php
+++ b/index.php
@@ -19,6 +19,7 @@ $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?php echo htmlspecialchars($blog_title); ?></title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1><?php echo htmlspecialchars($blog_title); ?></h1>

--- a/login.php
+++ b/login.php
@@ -24,6 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Login</title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1>Login</h1>

--- a/new_post.php
+++ b/new_post.php
@@ -45,14 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>New Post</title>
-<style>
-input[type="text"],
-.editor-field {
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-}
-</style>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1>New Post</h1>

--- a/new_section.php
+++ b/new_section.php
@@ -40,6 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>New Section</title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,7 @@
+input[type="text"],
+input[type="password"],
+textarea {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}

--- a/view_post.php
+++ b/view_post.php
@@ -26,6 +26,7 @@ if ($post['section_id']) {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?php echo htmlspecialchars($post['title']); ?> - <?php echo htmlspecialchars($blog_title); ?></title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>

--- a/view_section.php
+++ b/view_section.php
@@ -38,6 +38,7 @@ $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?php echo htmlspecialchars($section['title']); ?> - <?php echo htmlspecialchars($blog_title); ?></title>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>


### PR DESCRIPTION
## Summary
- add a shared stylesheet that sets text and password inputs and textareas to use the full available width
- link the stylesheet from each page so all form fields inherit the consistent full-width behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2688d0c1c832b8ff61330e74c6fd4