### PR TITLE
Add Settings page and default post visibility preference

### DIFF
--- a/db.php
+++ b/db.php
@@ -28,6 +28,12 @@ function get_db() {
             $insert = $db->prepare("INSERT INTO settings (key, value) VALUES ('blog_title', 'Blog')");
             $insert->execute();
         }
+        $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'default_post_visibility'");
+        $stmt->execute();
+        if ($stmt->fetch(PDO::FETCH_ASSOC)['count'] == 0) {
+            $insert = $db->prepare("INSERT INTO settings (key, value) VALUES ('default_post_visibility', 'public')");
+            $insert->execute();
+        }
         $stmt = $db->query("SELECT COUNT(*) as count FROM users");
         $count = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
         if ($count == 0) {
@@ -52,5 +58,23 @@ function set_blog_title($title) {
     $db = get_db();
     $stmt = $db->prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('blog_title', ?)");
     $stmt->execute([$title]);
+}
+
+function get_default_post_visibility() {
+    $db = get_db();
+    $stmt = $db->prepare("SELECT value FROM settings WHERE key = 'default_post_visibility'");
+    $stmt->execute();
+    $value = $stmt->fetchColumn();
+    if ($value === false) {
+        return 1;
+    }
+    return $value === 'private' ? 0 : 1;
+}
+
+function set_default_post_visibility($is_public) {
+    $db = get_db();
+    $value = $is_public ? 'public' : 'private';
+    $stmt = $db->prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('default_post_visibility', ?)");
+    $stmt->execute([$value]);
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 <h1><?php echo htmlspecialchars($blog_title); ?></h1>
 <h2>Index</h2>
 <?php if (is_logged_in()): ?>
-<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_section.php">New Section</a> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Edit Account</a> | <a href="logout.php">Logout</a></p>
+<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_section.php">New Section</a> | <a href="new_post.php">New Post</a> | <a href="settings.php">Settings</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Edit Account</a> | <a href="logout.php">Logout</a></p>
 <?php else: ?>
 <p><a href="login.php">Login</a></p>
 <?php endif; ?>

--- a/new_post.php
+++ b/new_post.php
@@ -7,7 +7,9 @@ $title = '';
 $content = '';
 $message = '';
 $section_id = isset($_GET['section_id']) ? intval($_GET['section_id']) : intval($_POST['section_id'] ?? 0);
-$is_public = isset($_POST['is_public']) ? (int)($_POST['is_public'] === '1') : 1;
+$is_public = isset($_POST['is_public'])
+    ? (int)($_POST['is_public'] === '1')
+    : get_default_post_visibility();
 
 $section = null;
 if ($section_id) {

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$default_visibility = get_default_post_visibility();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $selected = $_POST['default_visibility'] ?? 'public';
+    $is_public = $selected === 'public';
+    set_default_post_visibility($is_public);
+    header('Location: index.php');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Settings</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<h1>Settings</h1>
+<form method="post">
+    <fieldset>
+        <legend>Default Post Visibility</legend>
+        <label>
+            <input type="radio" name="default_visibility" value="public" <?php echo $default_visibility ? 'checked' : ''; ?>>
+            Public
+        </label>
+        <label>
+            <input type="radio" name="default_visibility" value="private" <?php echo !$default_visibility ? 'checked' : ''; ?>>
+            Private
+        </label>
+    </fieldset>
+    <button type="submit">Save</button>
+</form>
+<p><a href="index.php">Back to Index</a></p>
+</body>
+</html>

--- a/view_section.php
+++ b/view_section.php
@@ -44,7 +44,7 @@ $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 <h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>
 <h2><?php echo htmlspecialchars($section['title']); ?></h2>
 <?php if (is_logged_in()): ?>
-<p><a href="new_section.php?parent_id=<?php echo $section['id']; ?>">New Subsection</a> | <a href="new_post.php?section_id=<?php echo $section['id']; ?>">New Post</a> | <a href="edit_section.php?id=<?php echo $section['id']; ?>">Edit Section</a> | <a href="delete_section.php?id=<?php echo $section['id']; ?>" onclick="return confirm('Delete this section?');">Delete Section</a></p>
+<p><a href="new_section.php?parent_id=<?php echo $section['id']; ?>">New Subsection</a> | <a href="new_post.php?section_id=<?php echo $section['id']; ?>">New Post</a> | <a href="settings.php">Settings</a> | <a href="edit_section.php?id=<?php echo $section['id']; ?>">Edit Section</a> | <a href="delete_section.php?id=<?php echo $section['id']; ?>" onclick="return confirm('Delete this section?');">Delete Section</a></p>
 <?php endif; ?>
 <?php if (!empty($subsections)): ?>
 <h3>Sections</h3>


### PR DESCRIPTION
### Motivation
- Allow administrators to control whether new posts are created as public or private by default and surface that control in the navbar.

### Description
- Add a new `settings.php` page that requires login and lets the user choose the default post visibility (public/private) and save it via `set_default_post_visibility`.
- Extend `db.php` to ensure a `default_post_visibility` settings row exists and add `get_default_post_visibility()` and `set_default_post_visibility()` helpers.
- Update `new_post.php` to use `get_default_post_visibility()` as the initial `is_public` value for the post creation form.
- Add a `Settings` link to the logged-in navigation in `index.php` and `view_section.php` so admins can access the settings page.

### Testing
- Started the built-in PHP server with `php -S ...` and confirmed the server returned `200 OK` using `curl -I` (success).
- Ran Playwright scripts that produced debug screenshots for the login and index pages and saved artifacts (success).
- An initial Playwright run that tried to navigate to and interact with `settings.php` timed out while waiting for the login form (timeout), but subsequent debug captures of pages completed and artifacts were produced (partial success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698268a5f254832b8825f66324b7426c)