### PR TITLE
Add section visibility controls (public/private)

### DIFF
--- a/db.php
+++ b/db.php
@@ -6,7 +6,7 @@ function get_db() {
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
         $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, section_id INTEGER, is_public INTEGER NOT NULL DEFAULT 1)");
-        $db->exec("CREATE TABLE IF NOT EXISTS sections (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, parent_id INTEGER REFERENCES sections(id), template TEXT DEFAULT '')");
+        $db->exec("CREATE TABLE IF NOT EXISTS sections (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, parent_id INTEGER REFERENCES sections(id), template TEXT DEFAULT '', is_public INTEGER NOT NULL DEFAULT 1)");
         $db->exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
 
         // Ensure the section_id column exists for older installations
@@ -22,6 +22,9 @@ function get_db() {
         if (!in_array('template', $sectionColumns)) {
             $db->exec("ALTER TABLE sections ADD COLUMN template TEXT DEFAULT ''");
         }
+        if (!in_array('is_public', $sectionColumns)) {
+            $db->exec("ALTER TABLE sections ADD COLUMN is_public INTEGER NOT NULL DEFAULT 1");
+        }
         $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'blog_title'");
         $stmt->execute();
         if ($stmt->fetch(PDO::FETCH_ASSOC)['count'] == 0) {
@@ -32,6 +35,12 @@ function get_db() {
         $stmt->execute();
         if ($stmt->fetch(PDO::FETCH_ASSOC)['count'] == 0) {
             $insert = $db->prepare("INSERT INTO settings (key, value) VALUES ('default_post_visibility', 'public')");
+            $insert->execute();
+        }
+        $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'default_section_visibility'");
+        $stmt->execute();
+        if ($stmt->fetch(PDO::FETCH_ASSOC)['count'] == 0) {
+            $insert = $db->prepare("INSERT INTO settings (key, value) VALUES ('default_section_visibility', 'public')");
             $insert->execute();
         }
         $stmt = $db->query("SELECT COUNT(*) as count FROM users");
@@ -75,6 +84,24 @@ function set_default_post_visibility($is_public) {
     $db = get_db();
     $value = $is_public ? 'public' : 'private';
     $stmt = $db->prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('default_post_visibility', ?)");
+    $stmt->execute([$value]);
+}
+
+function get_default_section_visibility() {
+    $db = get_db();
+    $stmt = $db->prepare("SELECT value FROM settings WHERE key = 'default_section_visibility'");
+    $stmt->execute();
+    $value = $stmt->fetchColumn();
+    if ($value === false) {
+        return 1;
+    }
+    return $value === 'private' ? 0 : 1;
+}
+
+function set_default_section_visibility($is_public) {
+    $db = get_db();
+    $value = $is_public ? 'public' : 'private';
+    $stmt = $db->prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('default_section_visibility', ?)");
     $stmt->execute([$value]);
 }
 ?>

--- a/edit_section.php
+++ b/edit_section.php
@@ -6,7 +6,7 @@ $db = get_db();
 $blog_title = get_blog_title();
 
 $id = intval($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT title, parent_id, template FROM sections WHERE id = ?");
+$stmt = $db->prepare("SELECT title, parent_id, template, is_public FROM sections WHERE id = ?");
 $stmt->execute([$id]);
 $section = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$section) {
@@ -17,15 +17,18 @@ if (!$section) {
 $title = $section['title'];
 $template = $section['template'] ?? '';
 $parent_id = (int)$section['parent_id'];
+$is_public = (int)($section['is_public'] ?? 1);
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $title = ucwords(strtolower($title));
     $template = $_POST['template'] ?? '';
+    $visibility = $_POST['visibility'] ?? ($is_public ? 'public' : 'private');
+    $is_public = $visibility === 'public' ? 1 : 0;
     if ($title) {
-        $update = $db->prepare("UPDATE sections SET title = ?, template = ? WHERE id = ?");
-        $update->execute([$title, $template, $id]);
+        $update = $db->prepare("UPDATE sections SET title = ?, template = ?, is_public = ? WHERE id = ?");
+        $update->execute([$title, $template, $is_public, $id]);
         header('Location: view_section.php?id=' . $id);
         exit();
     } else {
@@ -54,6 +57,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <label for="template">Template</label>
         <textarea name="template" id="template" rows="8" cols="60"><?php echo htmlspecialchars($template); ?></textarea>
     </div>
+    <fieldset>
+        <legend>Visibility</legend>
+        <label>
+            <input type="radio" name="visibility" value="public" <?php echo $is_public ? 'checked' : ''; ?>>
+            Public
+        </label>
+        <label>
+            <input type="radio" name="visibility" value="private" <?php echo !$is_public ? 'checked' : ''; ?>>
+            Private
+        </label>
+    </fieldset>
     <button type="submit">Update</button>
 </form>
 <p><a href="view_section.php?id=<?php echo $id; ?>">Back to <?php echo htmlspecialchars($title); ?></a></p>

--- a/index.php
+++ b/index.php
@@ -3,7 +3,13 @@ require_once __DIR__ . '/auth.php';
 $db = get_db();
 $blog_title = get_blog_title();
 
-$sections = $db->query("SELECT id, title FROM sections WHERE parent_id IS NULL ORDER BY title")->fetchAll(PDO::FETCH_ASSOC);
+if (is_logged_in()) {
+    $sections = $db->query("SELECT id, title FROM sections WHERE parent_id IS NULL ORDER BY title")->fetchAll(PDO::FETCH_ASSOC);
+} else {
+    $sectionStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id IS NULL AND is_public = 1 ORDER BY title");
+    $sectionStmt->execute();
+    $sections = $sectionStmt->fetchAll(PDO::FETCH_ASSOC);
+}
 if (is_logged_in()) {
     $postStmt = $db->prepare("SELECT id, title FROM posts WHERE section_id IS NULL ORDER BY created_at DESC");
     $postStmt->execute();

--- a/new_section.php
+++ b/new_section.php
@@ -14,15 +14,18 @@ if ($parent_id) {
 }
 $title = '';
 $template = '';
+$is_public = get_default_section_visibility();
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $title = ucwords(strtolower($title));
     $template = $_POST['template'] ?? '';
+    $visibility = $_POST['visibility'] ?? ($is_public ? 'public' : 'private');
+    $is_public = $visibility === 'public' ? 1 : 0;
     if ($title) {
-        $stmt = $db->prepare("INSERT INTO sections (title, parent_id, template) VALUES (?, ?, ?)");
-        $stmt->execute([$title, $parent_id ?: null, $template]);
+        $stmt = $db->prepare("INSERT INTO sections (title, parent_id, template, is_public) VALUES (?, ?, ?, ?)");
+        $stmt->execute([$title, $parent_id ?: null, $template, $is_public]);
         if ($parent_id) {
             header('Location: view_section.php?id=' . $parent_id);
         } else {
@@ -55,6 +58,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <label for="template">Template</label>
         <textarea name="template" id="template" rows="8" cols="60"><?php echo htmlspecialchars($template); ?></textarea>
     </div>
+    <fieldset>
+        <legend>Visibility</legend>
+        <label>
+            <input type="radio" name="visibility" value="public" <?php echo $is_public ? 'checked' : ''; ?>>
+            Public
+        </label>
+        <label>
+            <input type="radio" name="visibility" value="private" <?php echo !$is_public ? 'checked' : ''; ?>>
+            Private
+        </label>
+    </fieldset>
     <input type="hidden" name="parent_id" value="<?php echo htmlspecialchars($parent_id); ?>">
     <button type="submit">Create</button>
 </form>

--- a/settings.php
+++ b/settings.php
@@ -2,12 +2,14 @@
 require_once __DIR__ . '/auth.php';
 require_login();
 
-$default_visibility = get_default_post_visibility();
+$default_post_visibility = get_default_post_visibility();
+$default_section_visibility = get_default_section_visibility();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $selected = $_POST['default_visibility'] ?? 'public';
-    $is_public = $selected === 'public';
-    set_default_post_visibility($is_public);
+    $post_visibility = $_POST['default_post_visibility'] ?? 'public';
+    $section_visibility = $_POST['default_section_visibility'] ?? 'public';
+    set_default_post_visibility($post_visibility === 'public');
+    set_default_section_visibility($section_visibility === 'public');
     header('Location: index.php');
     exit();
 }
@@ -26,11 +28,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <fieldset>
         <legend>Default Post Visibility</legend>
         <label>
-            <input type="radio" name="default_visibility" value="public" <?php echo $default_visibility ? 'checked' : ''; ?>>
+            <input type="radio" name="default_post_visibility" value="public" <?php echo $default_post_visibility ? 'checked' : ''; ?>>
             Public
         </label>
         <label>
-            <input type="radio" name="default_visibility" value="private" <?php echo !$default_visibility ? 'checked' : ''; ?>>
+            <input type="radio" name="default_post_visibility" value="private" <?php echo !$default_post_visibility ? 'checked' : ''; ?>>
+            Private
+        </label>
+    </fieldset>
+    <fieldset>
+        <legend>Default Section Visibility</legend>
+        <label>
+            <input type="radio" name="default_section_visibility" value="public" <?php echo $default_section_visibility ? 'checked' : ''; ?>>
+            Public
+        </label>
+        <label>
+            <input type="radio" name="default_section_visibility" value="private" <?php echo !$default_section_visibility ? 'checked' : ''; ?>>
             Private
         </label>
     </fieldset>

--- a/view_section.php
+++ b/view_section.php
@@ -4,7 +4,7 @@ $db = get_db();
 $blog_title = get_blog_title();
 
 $id = intval($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT id, title, parent_id FROM sections WHERE id = ?");
+$stmt = $db->prepare("SELECT id, title, parent_id, is_public FROM sections WHERE id = ?");
 $stmt->execute([$id]);
 $section = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$section) {
@@ -12,15 +12,29 @@ if (!$section) {
     echo "<p>Section not found.</p>\n";
     exit();
 }
+if (!is_logged_in() && !(int)$section['is_public']) {
+    http_response_code(404);
+    echo "<p>Section not found.</p>\n";
+    exit();
+}
 
 $parent = null;
 if ($section['parent_id']) {
-    $parentStmt = $db->prepare("SELECT id, title FROM sections WHERE id = ?");
-    $parentStmt->execute([$section['parent_id']]);
+    if (is_logged_in()) {
+        $parentStmt = $db->prepare("SELECT id, title FROM sections WHERE id = ?");
+        $parentStmt->execute([$section['parent_id']]);
+    } else {
+        $parentStmt = $db->prepare("SELECT id, title FROM sections WHERE id = ? AND is_public = 1");
+        $parentStmt->execute([$section['parent_id']]);
+    }
     $parent = $parentStmt->fetch(PDO::FETCH_ASSOC);
 }
 
-$subStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id = ? ORDER BY title");
+if (is_logged_in()) {
+    $subStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id = ? ORDER BY title");
+} else {
+    $subStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id = ? AND is_public = 1 ORDER BY title");
+}
 $subStmt->execute([$id]);
 $subsections = $subStmt->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
### Motivation
- Add per-section public/private visibility so sections can be hidden from anonymous users and have a configurable default.
- Expose a settings UI to control the default visibility for new sections and allow editors to set visibility when creating or editing a section.

### Description
- Add an `is_public` column to the `sections` table and ensure older installations are migrated by adding the column via `ALTER TABLE` when missing in `db.php`, and add `default_section_visibility` to `settings` with `get_default_section_visibility()` and `set_default_section_visibility()` helpers.
- Update the settings page (`settings.php`) to show and persist `Default Section Visibility` alongside post visibility and use `default_section_visibility` when creating sections.
- Update the new section flow (`new_section.php`) to use the default visibility and store `is_public` when inserting a section, and add a visibility radio field to the form.
- Update the edit section flow (`edit_section.php`) to load and persist `is_public` and add a visibility radio field to the edit form.
- Restrict visibility for anonymous users by filtering sections in `index.php` and `view_section.php`, and return 404 for private sections when accessed by non-logged-in users; also filter parent/subsection listings to only show public subsections to anonymous users.

### Testing
- Started the PHP development server with `php -S 0.0.0.0:8000` (server started successfully).
- Ran an automated Playwright script to log in and capture the `settings.php` page, but the Playwright/Chromium launcher crashed in the container and the screenshot attempt failed. No further automated tests were available or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982727eb4e0832bbba78db1b80340f8)